### PR TITLE
Add "patch" method on the Asset API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Change Log
 
-The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release. 
+The change log describes what is "Added", "Removed", "Changed" or "Fixed" between each release.
+
+## Unreleased
+
+### Added
+
+- New Assert Patch method, from https://localise.biz/api/docs/assets/patchasset
+
+## 0.2.2
+
+### Fixed
+
+- Fix error status code parsing
 
 ## 0.2.1
 

--- a/src/Api/Asset.php
+++ b/src/Api/Asset.php
@@ -53,4 +53,54 @@ class Asset extends HttpApi
 
         return $this->hydrator->hydrate($response, AssetModel::class);
     }
+
+    /**
+     * Patch an asset.
+     * {@link https://localise.biz/api/docs/assets/patchasset}.
+     *
+     * @param string $projectKey
+     * @param string $id
+     * @param string $type
+     * @param string $name
+     * @param string $context
+     * @param string $notes
+     *
+     * @return AssetModel|ResponseInterface
+     *
+     * @throws Exception
+     */
+    public function patch(string $projectKey, string $id, $type = null, $name = null, $context = null, $notes = null)
+    {
+        $param = [
+            'id' => $id,
+        ];
+
+        if ($type) {
+            $param['type'] = $type;
+        }
+        if ($name) {
+            $param['name'] = $name;
+        }
+        if ($context) {
+            $param['context'] = $context;
+        }
+        if ($notes) {
+            $param['notes'] = $notes;
+        }
+
+        $response = $this->httpPatch(sprintf('/api/assets/%s.json?key=%s', $id, $projectKey), $param);
+        if (!$this->hydrator) {
+            return $response;
+        }
+
+        if ($response->getStatusCode() === 409) {
+            throw Exception\Domain\AssetConflictException::create($id);
+        }
+
+        if ($response->getStatusCode() >= 400) {
+            $this->handleErrors($response);
+        }
+
+        return $this->hydrator->hydrate($response, AssetModel::class);
+    }
 }

--- a/src/Api/HttpApi.php
+++ b/src/Api/HttpApi.php
@@ -122,6 +122,24 @@ abstract class HttpApi
     }
 
     /**
+     * Send a PATCH request with JSON-encoded parameters.
+     *
+     * @param string $path           Request path
+     * @param array  $params         PATCH parameters to be JSON encoded
+     * @param array  $requestHeaders Request headers
+     *
+     * @return ResponseInterface
+     */
+    protected function httpPatch(string $path, array $params = [], array $requestHeaders = []): ResponseInterface
+    {
+        $requestHeaders['Content-Type'] = 'application/json';
+
+        return $this->httpClient->sendRequest(
+            $this->requestBuilder->create('PATCH', $path, $requestHeaders, json_encode($params))
+        );
+    }
+
+    /**
      * Send a DELETE request with JSON-encoded parameters.
      *
      * @param string $path           Request path


### PR DESCRIPTION
Allow to use the https://localise.biz/api/docs/assets/patchasset API, to update an existing Asset.

This method is required to add notes on existing assets in Loco.

Note that it uses `json_encode` unlike the other methods, that's because this API can't be hit with basic `application/x-www-form-urlencoded` body.