### PR TITLE
fixes #21 A "conflict" response from API is not handled properly

### DIFF
--- a/src/Api/Asset.php
+++ b/src/Api/Asset.php
@@ -43,12 +43,12 @@ class Asset extends HttpApi
             return $response;
         }
 
-        if ($response->getStatusCode() !== 201) {
-            $this->handleErrors($response);
-        }
-
         if ($response->getStatusCode() === 409) {
             throw Exception\Domain\AssetConflictException::create($id);
+        }
+
+        if ($response->getStatusCode() !== 201) {
+            $this->handleErrors($response);
         }
 
         return $this->hydrator->hydrate($response, AssetModel::class);


### PR DESCRIPTION
Error was handled by function in HttpApi class, and that method did not recognize the "AssetConflictException" returning "UnknownErrorException" instead, rather than passing it to the outisde.

On the other end, the loco adapter has a code responsible for detecting this case:

```
        try {
            // Create asset first
            $this->client->asset()->create($projectKey, $message->getKey());
            $this->client->translations()->create($projectKey, $message->getKey(), $message->getLocale(), $message->getTranslation());
        } catch (AssetConflictException $e) {
            // This is okey
            $isNewAsset = false;
        }
```
