### PR TITLE
Add support for creating "null" translations

### DIFF
--- a/src/Api/Translation.php
+++ b/src/Api/Translation.php
@@ -59,7 +59,7 @@ class Translation extends HttpApi
      *
      * @throws Exception
      */
-    public function create(string $projectKey, string $id, string $locale, string $translation)
+    public function create(string $projectKey, string $id, string $locale, string $translation = null)
     {
         $response = $this->httpPostRaw(sprintf('/api/translations/%s/%s?key=%s', $id, $locale, $projectKey), $translation);
         if (!$this->hydrator) {


### PR DESCRIPTION
We should be able to tell in the client if the translation beeing created was not specified or if it was an empty string set on purpose.
